### PR TITLE
Improve FreeSWITCH error reporting

### DIFF
--- a/sandswitches/manage.py
+++ b/sandswitches/manage.py
@@ -59,8 +59,10 @@ class cli(object):
         except ProcessExecutionError as err:
             raise CLIConnectionError(str(err))
 
-        if '-ERR' in out:
+        lines = out.splitlines()
+        if lines and lines[-1].startswith('-ERR'):
             raise CLIError(out)
+
         if erroron:
             for name, func in erroron.items():
                 if func(out):


### PR DESCRIPTION
Its only a problem if the last line starts with -ERR, there are plenty of cases where the current logic leads to false positives. For example:

    -ERR unloading module [No such module!]
    +OK Reloading XML
    +OK module loaded

This is not a failure.