### PR TITLE
Make module APIs separate from config API

### DIFF
--- a/sandswitches/manage.py
+++ b/sandswitches/manage.py
@@ -9,12 +9,11 @@ import logging
 import os
 import tempfile
 from io import BytesIO
-from collections import namedtuple
 from lxml import etree
 from plumbum import ProcessExecutionError
 from .utils import RestoreFile
 from .orms import buildfromschema
-from .schema import _models
+from .schema import _sections, _apis
 
 
 log = logging.getLogger('sandswitches')
@@ -75,7 +74,7 @@ class cli(object):
         return self('eval', expr)
 
 
-class ConfigManager(object):
+class Client(object):
     '''Manages a collection of restorable XML objects discovered in the
     FreeSWITCH config directories.
     '''
@@ -114,67 +113,6 @@ class ConfigManager(object):
         log.debug("freeswitch.xml commit took {} seconds"
                   .format(time.time() - now))
 
-    def sofia_status(self):
-        """Return status data from sofia in a nicely organized dict.
-        """
-        # remove '===' "lines"
-        lines = [
-            line for line in self.fscli('sofia', 'status').splitlines()
-            if '===' not in line]
-        # pop summary line
-        lines.pop(-1)
-
-        # build component to status maps
-        profiles = {}
-        gateways = {}
-        aliases = {}
-
-        colnames = [name.lower() for name in lines.pop(0).split()]
-        iname = colnames.index('name')
-        colnames.remove('name')
-        for line in lines:
-            fields = [field.strip() for field in line.split('\t')]
-            name = fields.pop(iname)
-            row = {k.lower(): v for k, v in zip(colnames, fields)}
-            tp = row.pop('type')
-            if tp == 'profile':
-                profiles[name] = row
-            elif tp == 'gateway':
-                profname, gwname = name.split("::")
-                row['profile'] = profname
-                gateways[gwname] = row
-            elif tp == 'alias':
-                aliases[name] = row
-
-        return {'profiles': profiles, 'gateways': gateways, 'aliases': aliases}
-
-    def get_users(self, **kwargs):
-        """Return all directory users in a map keyed by domain name.
-        """
-        args = []
-        allowed = ('domain', 'group', 'user', 'context')
-        for argname, value in kwargs.items():
-            if argname not in allowed:
-                raise ValueError(
-                    '{} is not a valid argument to list_users'.format(
-                        argname)
-                )
-            args.append('{} {}'.format(argname, value))
-
-        # last two lines are entirely useless
-        res = self.cli('list_users', *args).splitlines()[:-2]
-        UserEntry = namedtuple("UserEntry", res[0].split('|'))
-        # collect and pack all users
-        users = []
-        for row in res[1:]:
-            users.append(UserEntry(*row.split('|')))
-
-        # pack users by domain
-        domains = {}
-        for user in users:
-            domains.setdefault(user.domain, []).append(user)
-
-        return domains
 
 
 def manage_config(rootpath, sftp, fscli, log, singlefile=True):
@@ -222,17 +160,30 @@ def manage_config(rootpath, sftp, fscli, log, singlefile=True):
         with sftp.open(confpath, 'w') as fxml:
             fxml.write(etree.tostring(tree, pretty_print=True))
 
-    mng = ConfigManager(
+    client = Client(
         RestoreFile(confpath, open=sftp.open if sftp else open),
         tree, sftp, fscli, log
     )
 
-    # apply section mapped models as attrs
-    for f, cls in _models:
-        section = buildfromschema(
-            cls, getattr(cls, 'schema', None), root=mng.root,
-            log=log, confmng=mng
-        )
-        setattr(mng, section.name, section)
+    class Api(object):
+        "Module api placeholder"
+        def __init__(self, client):
+            self.client = client
 
-    return mng
+    # apply section mapped apis/models as attrs
+    for f, cls in _sections:
+        modname = cls.modeldata['modname']
+        api = _apis.get(modname)
+        if api:
+            module = api(client)
+        else:
+            module = Api(client)
+
+        setattr(client, modname, module)
+        section = buildfromschema(
+            cls, getattr(cls, 'schema', None), root=client.root,
+            log=log, client=client
+        )
+        setattr(module, 'config', section)
+
+    return client

--- a/sandswitches/orms.py
+++ b/sandswitches/orms.py
@@ -20,7 +20,7 @@ class EtreeMapper(object):
     # A shitty mechanism to pass instance variable state into new instances
     kwargs = {}
 
-    def __init__(self, name, path, tag, elem, confmng, **kwargs):
+    def __init__(self, name, path, tag, elem, client, **kwargs):
         self.name = name
         self.path = path  # relative xpath
         self.tag = tag
@@ -30,7 +30,7 @@ class EtreeMapper(object):
         # section of concern which when combined with self.path points to the
         # "parent" etree element.
         self.elem = elem
-        self.confmng = confmng
+        self.client = client
         self.attrs = set()
         kwds = deepcopy(type(self).kwargs)
         kwds.update(kwargs)
@@ -49,7 +49,7 @@ class EtreeMapper(object):
             kwargs[attr] = getattr(self, attr)
         kwargs['key'] = key  # adds a self.key attr to the new inst
         inst = type(self)(
-            self.name, self.path, self.tag, elem, self.confmng, **kwargs
+            self.name, self.path, self.tag, elem, self.client, **kwargs
         )
         for name in self.attrs:
             setattr(inst, name, getattr(self, name))
@@ -85,13 +85,13 @@ class EtreeMapper(object):
     def epath(self):
         """The element path to ``self.elem``.
         """
-        return self.confmng.etree.getelementpath(self.elem)
+        return self.client.etree.getelementpath(self.elem)
 
     @property
     def xpath(self):
         """The xpath to ``self.elem``.
         """
-        return self.confmng.etree.getpath(self.elem)
+        return self.client.etree.getpath(self.elem)
 
     def toxmlstring(self):
         """Render this mapping to an XML string.
@@ -438,7 +438,7 @@ def buildfromschema(obj, schemadict, **kwargs):
     # Initial unbuilt section type (i.e. anything marked as a "schema.model").
     if isinstance(obj, type):
         obj = obj(
-            name=obj.modeldata['id'],
+            name=obj.modeldata['modname'],
             path=getattr(obj, 'path', '.'),
             tag=getattr(obj, 'tag', '.'),
             elem=kwargs['root'].xpath(obj.modeldata['xpath'])[0],
@@ -467,7 +467,7 @@ def buildfromschema(obj, schemadict, **kwargs):
                 path=args.pop('path', attrpath),
                 tag=args.pop('tag'),
                 elem=obj.elem,
-                confmng=obj.confmng,
+                client=obj.client,
                 **args
             )
             # support maptype subclasses which define further schema

--- a/sandswitches/schema.py
+++ b/sandswitches/schema.py
@@ -4,6 +4,7 @@ for each FreeSWITCH XML configuration "section".
 """
 import time
 import logging
+from collections import namedtuple
 from .orms import (
     TagMap, ElemMap, SpecialAttrsMap, AttrMap, ElemList
 )
@@ -12,15 +13,16 @@ from .orms import (
 log = logging.getLogger('sandswitches')
 
 
-_models = []
+_sections = []
+_apis = {}
 
 
-def model(**kwargs):
-    """Decorator for registering config models with meta data to be matched
+def section(**kwargs):
+    """Decorator for registering config schema with meta data to be matched
     against when a config file is loaded.
     """
     def inner(cls):
-        _models.append((
+        _sections.append((
             lambda d: any(d[key] == value for key, value in kwargs.items()),
             cls
         ))
@@ -30,14 +32,24 @@ def model(**kwargs):
     return inner
 
 
-def get_model(**kwargs):
-    """Retrieve a model matching provided meta data.
+def get_section(**kwargs):
+    """Retrieve a section matching provided meta data.
     """
-    for f, cls in _models:
+    for f, cls in _sections:
         if f(kwargs):
             return cls
 
     return TagMap
+
+
+def api(modname):
+    """Mark a class as being an api module.
+    """
+    def inner(cls):
+        _apis[modname] = cls
+        return cls
+
+    return inner
 
 
 class SofiaProfile(TagMap):
@@ -72,72 +84,10 @@ class SofiaProfile(TagMap):
         },
     }
 
-    def start(self, timeout=11):
-        """Start this sofia profile.
-        If not started within ``timeout`` seconds, raise an error.
-        """
-        start = time.time()
-        log.info("starting profile '{}'".format(self.key))
-        self.confmng.fscli('sofia', 'profile', self.key, 'start',
-                           checkfail=lambda out: 'Failure'in out)
-        # poll for profile to come up
-        while 'Invalid Profile' in self.confmng.fscli(
-            'sofia', 'status', 'profile', self.key
-        ):
-            time.sleep(0.5)
-            if time.time() - start > timeout:
-                raise RuntimeError(
-                    "Failed to start '{}' after {} seconds".format(
-                        self.key, timeout)
-                )
 
-    def restart(self):
-        log.info("restarting profile '{}'".format(self.key))
-        self.confmng.fscli('sofia', 'profile', self.key, 'restart',
-                           checkfail=lambda out: 'Failure'in out)
-        # poll for profile to come up
-        while 'Invalid Profile' in self.confmng.fscli(
-            'sofia', 'status', 'profile', self.key
-        ):
-            time.sleep(0.5)
-
-    def stop(self, timeout=12):
-        """Stop this sofia profile.
-        If not stopped within ``timeout`` seconds, raise an error.
-        """
-        start = time.time()
-        log.info("stopping profile '{}'".format(self.key))
-        self.confmng.fscli('sofia', 'profile', self.key, 'stop',
-                           checkfail=lambda out: 'Failure'in out)
-
-        # poll for profile to shut down
-        while 'Invalid Profile' not in self.confmng.fscli(
-            'sofia', 'profile', self.key, 'stop',
-            checkfail=lambda out: 'Failure' in out
-        ):
-            time.sleep(1)
-            if time.time() - start > timeout:
-                raise RuntimeError(
-                    "Failed to stop '{}' after {} seconds".format(
-                        self.key, timeout)
-                )
-
-    def register(self, gateway):
-        self.confmng.fscli(
-            'sofia', 'profile', self.key, 'register', gateway,
-            checkgw=lambda out: 'Invalid gateway!' in out
-        )
-
-    def unregister(self, gateway):
-        self.confmng.fscli(
-            'sofia', 'profile', self.key, 'unregister', gateway,
-            checkgw=lambda out: 'Invalid gateway!' in out
-        )
-
-
-@model(
+@section(
     xpath='section/configuration[@name="sofia.conf"]',
-    id='sofia',
+    modname='sofia',
 )
 class SofiaConf(TagMap):
     """A schema for sip profile config files
@@ -161,9 +111,114 @@ class SofiaConf(TagMap):
     }
 
 
-@model(
+@api(modname='sofia')
+class SofiaApi(object):
+    """An API around ``mod_sofia``.
+    """
+    def __init__(self, client):
+        self.client = client
+        self.log = log.getChild('sofia')
+
+    def start(self, name, timeout=11):
+        """Start this sofia profile.
+        If not started within ``timeout`` seconds, raise an error.
+        """
+        start = time.time()
+        self.log.info("starting profile '{}'".format(name))
+        self.client.cli('sofia', 'profile', name, 'start',
+                        checkfail=lambda out: 'Failure'in out)
+        # poll for profile to come up
+        while 'Invalid Profile' in self.client.cli(
+            'sofia', 'status', 'profile', name
+        ):
+            time.sleep(0.5)
+            if time.time() - start > timeout:
+                raise RuntimeError(
+                    "Failed to start '{}' after {} seconds".format(
+                        name, timeout)
+                )
+
+    def restart(self, name):
+        self.log.info("restarting profile '{}'".format(name))
+        self.client.cli('sofia', 'profile', name, 'restart',
+                        checkfail=lambda out: 'Failure'in out)
+        # poll for profile to come up
+        while 'Invalid Profile' in self.client.cli(
+            'sofia', 'status', 'profile', name
+        ):
+            time.sleep(0.5)
+
+    def stop(self, name, timeout=12):
+        """Stop this sofia profile.
+        If not stopped within ``timeout`` seconds, raise an error.
+        """
+        start = time.time()
+        self.log.info("stopping profile '{}'".format(name))
+        self.client.cli('sofia', 'profile', name, 'stop',
+                        checkfail=lambda out: 'Failure'in out)
+
+        # poll for profile to shut down
+        while 'Invalid Profile' not in self.client.cli(
+            'sofia', 'profile', name, 'stop',
+            checkfail=lambda out: 'Failure' in out
+        ):
+            time.sleep(1)
+            if time.time() - start > timeout:
+                raise RuntimeError(
+                    "Failed to stop '{}' after {} seconds".format(
+                        name, timeout)
+                )
+
+    def register(self, name, gateway):
+        self.client.cli(
+            'sofia', 'profile', name, 'register', gateway,
+            checkgw=lambda out: 'Invalid gateway!' in out
+        )
+
+    def unregister(self, name, gateway):
+        self.client.cli(
+            'sofia', 'profile', name, 'unregister', gateway,
+            checkgw=lambda out: 'Invalid gateway!' in out
+        )
+
+    def status(self):
+        """Return status data from sofia in a nicely organized dict.
+        """
+        # remove '===' "lines"
+        lines = [
+            line for line in self.client.cli('sofia', 'status').splitlines()
+            if '===' not in line]
+        # pop summary line
+        lines.pop(-1)
+
+        # build component to status maps
+        profiles = {}
+        gateways = {}
+        aliases = {}
+
+        colnames = [name.lower() for name in lines.pop(0).split()]
+        iname = colnames.index('name')
+        colnames.remove('name')
+        for line in lines:
+            fields = [field.strip() for field in line.split('\t')]
+            name = fields.pop(iname)
+            row = {k.lower(): v for k, v in zip(colnames, fields)}
+            tp = row.pop('type')
+            if tp == 'profile':
+                profiles[name] = row
+            elif tp == 'gateway':
+                profname, gwname = name.split("::")
+                row['profile'] = profname
+                gateways[gwname] = row
+            elif tp == 'alias':
+                aliases[name] = row
+
+        return {'profiles': profiles, 'gateways': gateways, 'aliases': aliases}
+
+
+@section(
     xpath='section[@name="dialplan"]',
-    id='dialplans',
+    modname='dialplan',
 )
 class Dialplan(ElemMap):
     tag = 'context'
@@ -196,9 +251,45 @@ class Dialplan(ElemMap):
     }
 
 
-@model(
+@api(modname='directory')
+class DirectoryApi(object):
+    """An api around the directory subsystem.
+    """
+    def __init__(self, client):
+        self.client = client
+
+    def get_users(self, **kwargs):
+        """Return all directory users in a map keyed by domain name.
+        """
+        args = []
+        allowed = ('domain', 'group', 'user', 'context')
+        for argname, value in kwargs.items():
+            if argname not in allowed:
+                raise ValueError(
+                    '{} is not a valid argument to list_users'.format(
+                        argname)
+                )
+            args.append('{} {}'.format(argname, value))
+
+        # last two lines are entirely useless
+        res = self.client.cli('list_users', *args).splitlines()[:-2]
+        UserEntry = namedtuple("UserEntry", res[0].split('|'))
+        # collect and pack all users
+        users = []
+        for row in res[1:]:
+            users.append(UserEntry(*row.split('|')))
+
+        # pack users by domain
+        domains = {}
+        for user in users:
+            domains.setdefault(user.domain, []).append(user)
+
+        return domains
+
+
+@section(
     xpath='section[@name="directory"]',
-    id='directory'
+    modname='directory'
 )
 class Directory(ElemMap):
     """A schema for a "domains".
@@ -262,9 +353,9 @@ class Directory(ElemMap):
     }
 
 
-@model(
+@section(
     xpath='section/configuration[@name="event_socket.conf"]',
-    id='event_socket',
+    modname='event_socket',
 )
 class EventSocket(TagMap):
     path = '.'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,10 +185,9 @@ def mkprofile(confmng, sof_prof_template):
     profiles = []
 
     def profile(name):
-        # confmng.sofia.profiles['doggy'] = sof_prof_template
-        confmng.sofia.profiles[name] = sof_prof_template
+        confmng.sofia.config.profiles[name] = sof_prof_template
         confmng.commit()
-        prof = confmng.sofia.profiles[name]
+        prof = confmng.sofia.config.profiles[name]
         profiles.append(prof)
         return prof
 
@@ -196,9 +195,9 @@ def mkprofile(confmng, sof_prof_template):
 
     for profile in profiles:
         key = profile.key
-        del confmng.sofia.profiles[key]
-        if key in confmng.sofia_status()['profiles']:
-            profile.stop()
+        del confmng.sofia.config.profiles[key]
+        if key in confmng.sofia.status()['profiles']:
+            confmng.sofia.stop(profile.key)
 
     confmng.commit()
 
@@ -247,8 +246,8 @@ def domain(fshost, confmng, domain_template):
     """A test domain using a template.
     """
     name = socket.gethostbyname(fshost)
-    confmng.directory[name] = domain_template
+    confmng.directory.config[name] = domain_template
     confmng.commit()
-    yield confmng.directory[name]
-    del confmng.directory[name]
+    yield confmng.directory.config[name]
+    del confmng.directory.config[name]
     confmng.commit()

--- a/tests/test_autoload_configs.py
+++ b/tests/test_autoload_configs.py
@@ -9,7 +9,7 @@ import time
 
 
 def test_event_socket(confmng):
-    settings = confmng.event_socket['settings']
+    settings = confmng.event_socket.config['settings']
     pw = settings['password']
     settings['password'] = 'doggy'
     confmng.commit()

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -10,11 +10,11 @@ import pytest
 def test_read_directory_section(confmng):
     """Check that the entire section can be read via object maps without error.
     """
-    assert repr(confmng.directory)
+    assert repr(confmng.directory.config)
 
 
 def test_push_user(domain, confmng):
-    userdata = confmng.get_users()
+    userdata = confmng.directory.get_users()
     users = userdata[domain.key]
     assert len(users) == 1
     assert users[0].userid == 'doggy'
@@ -24,7 +24,7 @@ def test_user_count(confmng, domain):
     """Push 300 users, 100 each in a separate group and
     verify they can all be read back using the list_users cmd.
     """
-    orig_users = confmng.get_users()
+    orig_users = confmng.directory.get_users()
 
     for igroup in range(3):
         group = domain['groups'].appendfrom(
@@ -34,5 +34,5 @@ def test_user_count(confmng, domain):
         del group['users']['doggy']
 
     confmng.commit()
-    new_users = confmng.get_users()
+    new_users = confmng.directory.get_users()
     assert len(new_users[domain.key]) - len(orig_users[domain.key]) == 300

--- a/tests/test_register_users.py
+++ b/tests/test_register_users.py
@@ -32,22 +32,22 @@ def test_reg_to_user(fshost, domain, confmng, mkprofile):
         int(client['settings']['sip-port']) - 1)
     registrar['domains']['test'] = {'parse': 'false', 'aliase': 'true'}
     confmng.commit()
-    registrar.start()
-    client.start()
+    confmng.sofia.start(registrar.key)
+    confmng.sofia.start(client.key)
 
     # register the client gateway to our 'doggy' user
-    client.register('doggy')
+    confmng.sofia.register(client.key, 'doggy')
 
     # assert the reg was successful
     start = time.time()
     while time.time() - start < 5:
-        if confmng.sofia_status()['gateways']['doggy']['state'] == 'REGED':
+        if confmng.sofia.status()['gateways']['doggy']['state'] == 'REGED':
             break
         time.sleep(0.1)
     else:
-        assert confmng.sofia_status()['gateways']['doggy']['state'] == 'REGED'
+        assert confmng.sofia.status()['gateways']['doggy']['state'] == 'REGED'
 
     # TODO: maybe make a call from the client?
 
     # teardown
-    client.unregister('doggy')
+    confmng.sofia.unregister(client.key, 'doggy')

--- a/tests/test_sofia.py
+++ b/tests/test_sofia.py
@@ -22,29 +22,29 @@ def test_read_sofia_section(confmng):
 def test_create_sofia_profile(profile, confmng):
     """Ensure we can create a profile from scratch, start and stop it.
     """
-    assert profile.key not in confmng.sofia_status()['profiles']
-    profile.start()
-    assert profile.key in confmng.sofia_status()['profiles']
-    profile.stop()
-    assert profile.key not in confmng.sofia_status()['profiles']
+    assert profile.key not in confmng.sofia.status()['profiles']
+    confmng.sofia.start(profile.key)
+    assert profile.key in confmng.sofia.status()['profiles']
+    confmng.sofia.stop(profile.key)
+    assert profile.key not in confmng.sofia.status()['profiles']
 
 
 def test_sofia_profile_aliases(profile, confmng):
     name = 'myprofile'
     profile['aliases'].append(name)
     confmng.commit()
-    profile.start()
-    assert name in confmng.sofia_status()['aliases']
+    confmng.sofia.start(profile.key)
+    assert name in confmng.sofia.status()['aliases']
     time.sleep(0.5)
-    profile.stop()
+    confmng.sofia.stop(profile.key)
     profile['aliases'].insert(0, 'yourprofile')
     profile['aliases'].insert(1, '2yourprofile')
     assert ('yourprofile', '2yourprofile', name) == tuple(
             profile['aliases'])
     time.sleep(0.5)
-    profile.start()
+    confmng.sofia.start(profile.key)
     # FIXME: only the last alias is used? bug?
-    assert name in confmng.sofia_status()['aliases']
+    assert name in confmng.sofia.status()['aliases']
 
 
 def test_sofia_profile_gateway(profile, confmng):
@@ -59,35 +59,36 @@ def test_sofia_profile_gateway(profile, confmng):
         'ping': '30',
     }}
     confmng.commit()
-    profile.start()
-    gateways = confmng.sofia_status()['gateways']
+    confmng.sofia.start(profile.key)
+    gateways = confmng.sofia.status()['gateways']
     assert 'mygateway' in gateways
     gw = gateways['mygateway']
     assert '{}@{}'.format(user, domain) in gw['data']
 
 
 def test_sofia_append_from(profile, confmng):
-    newprof = confmng.sofia.profiles.appendfrom(profile.key, 'doggy2')
+    newprof = confmng.sofia.config.profiles.appendfrom(profile.key, 'doggy2')
     try:
-        assert newprof.key not in confmng.sofia_status()['profiles']
+        assert newprof.key not in confmng.sofia.status()['profiles']
         newprof['settings']['sip-port'] = '1001'
 
         # starting non-extant profile should fail
-        pytest.raises(confmng.fscli.CLIError, newprof.start)
+        with pytest.raises(confmng.cli.CLIError):
+            confmng.sofia.start(newprof.key)
 
         # push it and move on
         confmng.commit()
-        newprof.start()
-        profile.start()
-        assert newprof.key in confmng.sofia_status()['profiles']
-        assert profile.key in confmng.sofia_status()['profiles']
+        confmng.sofia.start(newprof.key)
+        confmng.sofia.start(profile.key)
+        assert newprof.key in confmng.sofia.status()['profiles']
+        assert profile.key in confmng.sofia.status()['profiles']
 
         # stop them both
-        profile.stop()
-        newprof.stop()
-        assert newprof.key not in confmng.sofia_status()['profiles']
-        assert profile.key not in confmng.sofia_status()['profiles']
+        confmng.sofia.stop(profile.key)
+        confmng.sofia.stop(newprof.key)
+        assert newprof.key not in confmng.sofia.status()['profiles']
+        assert profile.key not in confmng.sofia.status()['profiles']
     finally:
-        newprof.stop()
-        del confmng.sofia.profiles[newprof.key]
+        confmng.sofia.stop(newprof.key)
+        del confmng.sofia.config.profiles[newprof.key]
         confmng.commit()


### PR DESCRIPTION
Don't couple module apis with the corresponding configuration
sections. Instead have module APIs sit on their own and the
config api accessed as the ``Client.<module>.config`` attribute.

Resolves #9